### PR TITLE
Using find_packages to provide the package list

### DIFF
--- a/osxcollector/output_filters/opendns/lookup_domains.py
+++ b/osxcollector/output_filters/opendns/lookup_domains.py
@@ -146,8 +146,8 @@ class LookupDomainsFilter(ThreatFeedFilter):
         content_categories = category_info['content_categories']
         security_categories = category_info['security_categories']
 
-        return self._is_category_info_suspicious(category_info) or (0 == status and 0 == len(content_categories)
-                                                                    and 0 == len(security_categories))
+        return self._is_category_info_suspicious(category_info) or \
+            (0 == status and 0 == len(content_categories) and 0 == len(security_categories))
 
     def _is_security_info_suspicious(self, security_info):
         """Analyzes info from OpenDNS and makes a boolean determination of suspicious or not.

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from setuptools import find_packages
 from setuptools import setup
 
 setup(
@@ -10,7 +11,7 @@ setup(
     license="GNU General Public License",
     url="https://github.com/Yelp/osxcollector_output_filters",
     setup_requires="setuptools",
-    packages=["osxcollector"],
+    packages=find_packages(exclude=["tests"]),
     provides=["osxcollector"],
     install_requires=[
         "simplejson",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="osxcollector_output_filters",
-    version="1.0.1",
+    version="1.0.2",
     author="Yelp Security",
     author_email="opensource@yelp.com",
     description="Filters that process and transform the output of OSXCollector",

--- a/tests/output_filters/virustotal/lookup_hashes_test.py
+++ b/tests/output_filters/virustotal/lookup_hashes_test.py
@@ -33,7 +33,7 @@ class LookupHashesFilterTest(RunFilterTest):
                     'md5': '0c71d8cedc8bbb2b619a76d1478c4348',
                     'scan_date': '2015-01-15 16:42:01',
                     'permalink': 'https://www.virustotal.com/file/'
-                    + 'b779bafdf61b74784f2d3601ed663d7476da9ad4182601b8ca54fd4fbe1aa302/analysis/1273894724/',
+                    'b779bafdf61b74784f2d3601ed663d7476da9ad4182601b8ca54fd4fbe1aa302/analysis/1273894724/',
                     'total': 40,
                     'positives': 40,
                     'response_code': 1
@@ -47,7 +47,7 @@ class LookupHashesFilterTest(RunFilterTest):
                     'md5': '06506cc06cf0167ea583de62c98eae2c',
                     'scan_date': '2010-05-15 03:38:44',
                     'permalink': 'https://www.virustotal.com/file/'
-                    + '6e87855371171d912dd866e8d7747bf965c80053f83259827a55826ca38a9360/analysis/1273894724/',
+                    '6e87855371171d912dd866e8d7747bf965c80053f83259827a55826ca38a9360/analysis/1273894724/',
                     'total': 40,
                     'positives': 40,
                     'response_code': 1


### PR DESCRIPTION
It seems that because the packages list in `setup.py` was only containing `osxcollector` the module itself wasn't exposing anything in the packages underneath it, e.g. `osxcollector.output_filters`.