### PR TITLE
Returning blob instead of None in filter_line method

### DIFF
--- a/osxcollector/output_filters/analyze.py
+++ b/osxcollector/output_filters/analyze.py
@@ -264,7 +264,7 @@ class _VeryReadableOutputFilter(OutputFilter):
             if blob['osxcollector_section'] in ['firefox', 'chrome'] and blob.get('osxcollector_subsection') == 'extensions':
                 self._extensions.append(blob)
 
-        return None
+        return blob
 
     def _write(self, msg, color=END_COLOR):
         if not self._monochrome:


### PR DESCRIPTION
This change should make `output_stream` parameter in the `OutputFilter._run_filter` method more usable when run on `AnalyzeFilter` class.