### PR TITLE
Added 'output-file' argument for the OSXCollector output augmented with the filter results

### DIFF
--- a/osxcollector/output_filters/base_filters/output_filter.py
+++ b/osxcollector/output_filters/base_filters/output_filter.py
@@ -131,12 +131,19 @@ def run_filter_main(output_filter_cls):
     parser = ArgumentParser(parents=argument_parents, conflict_handler='resolve')
     parser.add_argument('-i', '--input-file', dest='input_file', default=None,
                         help='[OPTIONAL] Path to OSXCollector output to read. Defaults to stdin otherwise.')
+    parser.add_argument('-o', '--output-file', dest='output_file', default=None,
+                        help='[OPTIONAL] Path where OSXCollector output augmented with the analysis results will be written to. Defaults to stdout otherwise.')
     args = parser.parse_args()
 
     output_filter = output_filter_cls(**vars(args))
 
+    fp_in = open(args.input_file, 'r') if args.input_file else None
+    fp_out = open(args.output_file, 'w') if args.output_file else None
+
+    _run_filter(output_filter, input_stream=fp_in, output_stream=fp_out)
+
     if args.input_file:
-        with(open(args.input_file, 'r')) as fp_in:
-            _run_filter(output_filter, input_stream=fp_in)
-    else:
-        _run_filter(output_filter)
+        fp_in.close()
+
+    if args.output_file:
+        fp_out.close()

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="osxcollector_output_filters",
-    version="1.0.3",
+    version="1.0.4",
     author="Yelp Security",
     author_email="opensource@yelp.com",
     description="Filters that process and transform the output of OSXCollector",


### PR DESCRIPTION
OSXCollector output augmented with the analysis results was written to a file called `analyze_<CASE-ID>.json`.
This change adds the command line argument `-o` or `--ouput-file` which lets directly specifying the file to which the output should be written. If the parameter is not supplied, then the output is written to the standard output.