### PR TITLE
Issue 51 unicode decode error

### DIFF
--- a/osxcollector/output_filters/util/blacklist.py
+++ b/osxcollector/output_filters/util/blacklist.py
@@ -90,8 +90,10 @@ class Blacklist(object):
             try:
                 domain = clean_domain(blacklisted_value)
             except BadDomainError:
+                if not isinstance(blacklisted_value, unicode):
+                    blacklisted_value = blacklisted_value.decode('utf8')
                 logging.warning(
-                    'Blacklisted value "{0}" cannot be resolved as a domain name'
+                    u'Blacklisted value "{0}" cannot be resolved as a domain name'
                     .format(blacklisted_value))
                 return None
 

--- a/tests/output_filters/util/blacklist_test.py
+++ b/tests/output_filters/util/blacklist_test.py
@@ -80,14 +80,14 @@ class CreateBlacklistTest(T.TestCase):
         unicode_domains = [unicode_domain_1, unicode_domain_2, unicode_domain_3]
         self._blacklist_data['blacklist_is_domains'] = True
         with patch.object(Blacklist, '_read_blacklist_file_contents',
-                return_value=unicode_domains) as self._file_contents:
+                          return_value=unicode_domains) as self._file_contents:
             with patch('logging.warning', autospec=True) as patched_logging_warning:
-                blacklist = create_blacklist(self._blacklist_data)
+                create_blacklist(self._blacklist_data)
 
         T.assert_equal(3, patched_logging_warning.call_count)
         calls = [
-            call(u'Blacklisted value "{0}" cannot be resolved as a domain name'\
-                    .format(unicode_domain.decode('utf8'))) for unicode_domain in unicode_domains
+            call(u'Blacklisted value "{0}" cannot be resolved as a domain name'
+                 .format(unicode_domain.decode('utf8'))) for unicode_domain in unicode_domains
         ]
         T.assert_equal(calls, patched_logging_warning.call_args_list)
 
@@ -186,7 +186,7 @@ class CreateBlacklistTest(T.TestCase):
             'blacklist_file_path': 'not_really_a_blacklist.txt',
             'blacklist_is_domains': True
         }
-        file_contents = ['Bücher.tld', 'yelp.公司', 'www.Yülp.tld','иelф.р']
+        file_contents = ['Bücher.tld', 'yelp.公司', 'www.Yülp.tld', 'иelф.р']
         with \
                 patch.object(Blacklist, '_read_blacklist_file_contents', return_value=file_contents), \
                 patch('logging.warning', autospec=True) as patched_logging_warning:
@@ -194,8 +194,8 @@ class CreateBlacklistTest(T.TestCase):
 
         T.assert_equal(4, patched_logging_warning.call_count)
         calls = [
-            call(u'Blacklisted value "{0}" cannot be resolved as a domain name'\
-                    .format(domain.decode('utf8'))) for domain in file_contents
+            call(u'Blacklisted value "{0}" cannot be resolved as a domain name'
+                 .format(domain.decode('utf8'))) for domain in file_contents
         ]
         T.assert_equal(calls, patched_logging_warning.call_args_list)
 


### PR DESCRIPTION
Fix unicode errors related to logging mixes of unicode and ascii by default decoding anything not unicode as `utf-8`. In the future, we will aim to refactor the whole repository to support unicode better, but for now we will use this as a temporary fix to stop unicode decode error bleeding.