### PR TITLE
Create MANIFEST.in file to avoid IO errors related to reading README / LICENSE files not included by default

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md
+include LICENSE.md


### PR DESCRIPTION
Fixes #56.